### PR TITLE
fix outofbounds and add jbang option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,12 @@ This project uses a LLM to automatically generate the summarization of a blog po
 java -jar --enable-preview --enable-native-access=ALL-UNNAMED --add-modules jdk.incubator.vector target/quarkus-app/quarkus-run.jar https://www.infoq.com/articles/native-java-quarkus/
 ```
 
+or use the `summarize.java` script that will automatically handle it all using JBang:
+
+```shell
+jbang summarize.java https://www.infoq.com/articles/native-java-quarkus/
+```
+
 that will generate an output like the following:
 
 ```

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -1,0 +1,10 @@
+{
+  "catalogs": {},
+  "aliases": {
+    "doit": {
+      "script-ref": "summarize.java",
+      "java-agents": []
+    }
+  },
+  "templates": {}
+}

--- a/src/main/java/org/mfusco/sitesummarizer/SiteSummarizer.java
+++ b/src/main/java/org/mfusco/sitesummarizer/SiteSummarizer.java
@@ -29,7 +29,13 @@ class SiteSummarizer {
                 LOGGER.info("Summarizing content " + content.length() + " characters long");
                 return summarizerAiService.summarize(content);
             } catch (Exception e) {
-                content = content.substring(0, content.length() - 1_000);
+                if (content.length() > 1_000) {
+                    content = content.substring(0, content.length() - 1_000);
+                } else {
+                   // just keep it as it s too short to summarize
+                   return Multi.createFrom().item(content);
+
+                }
             }
         }
     }

--- a/summarize.java
+++ b/summarize.java
@@ -1,0 +1,27 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 21+
+//PREVIEW
+//JAVA_OPTIONS --enable-native-access=ALL-UNNAMED
+//MODULES jdk.incubator.vector
+//DEPS io.quarkus.platform:quarkus-bom:3.16.4@pom
+//DEPS io.quarkus:quarkus-rest
+//DEPS io.quarkus:quarkus-arc
+//DEPS io.quarkus:quarkus-smallrye-openapi
+//DEPS io.quarkiverse.langchain4j:quarkus-langchain4j-jlama:0.22.0.CR2
+//DEPS com.github.tjake:jlama-core:0.8.2
+//DEPS com.github.tjake:jlama-native:0.8.2
+//DEPS org.jsoup:jsoup:1.18.1
+
+//FILES src/main/resources/application.properties
+//SOURCES src/main/java/org/mfusco/sitesummarizer/SiteSummarizer.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/SiteSummarizerMain.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/SiteType.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/TextExtractor.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/SummarizerAiService.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/crawlers/SiteCrawler.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/crawlers/BlogCrawler.java
+//SOURCES src/main/java/org/mfusco/sitesummarizer/crawlers/WikipediaCrawler.java
+
+public class summarize {
+    
+} 


### PR DESCRIPTION
fix out of bounds bug that happens when text is less than a 1000 characters + add a `summarizer.java` you can just run using jbang and not have to deal with all the other flags nor even clone this repo to run inference with pure java.

after this you can do `jbang doit@mariofusco/site-summarizer` or directly using `jbang https://github.com/mariofucso/site-summarizer/blob/main/summarize.java`


you can try it using my branch with or `jbang doit@maxandersen/site-summarizer/jbang` or direct with `jbang https://github.com/maxandersen/site-summarizer/blob/jbang/summarize.java`
